### PR TITLE
Fleet Digital Edition ENL creation (requested by 2/01)

### DIFF
--- a/packages/common/components/blocks/publication.marko
+++ b/packages/common/components/blocks/publication.marko
@@ -32,7 +32,7 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
         $ const publicationDescription = defaultValue(input.publicationDescription, latestIssue.publication.description);
 
         <common-table width="100%" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
-          <if(imgWidth > 700)>
+          <if(imgWidth > 300)>
             <tr>
               <td width=imgWidth align="center" valign="center">
                 <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
@@ -51,6 +51,9 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
             <tr>
               <td width="100%" valign="top" style="padding-left: 20px;">
                 <common-table width="100%" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;">
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
                   <tr>
                     <td align="center">
                         <if(latestIssue.digitalEditionUrl)>

--- a/packages/common/components/blocks/publication.marko
+++ b/packages/common/components/blocks/publication.marko
@@ -21,6 +21,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
 });
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font: 300 16px/24px Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
 
+
 <common-table width="700" border="0" spacing=0 padding=0 align="center" style="border-top: 2px solid #eee; border-bottom: 2px solid #eee; padding: 20px 0;" class="main publication">
   <tr>
     <td style=`${mainTableStyle} padding: 20px;`>
@@ -31,6 +32,58 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
         $ const publicationDescription = defaultValue(input.publicationDescription, latestIssue.publication.description);
 
         <common-table width="100%" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+          <if(imgWidth > 700)>
+            <tr>
+              <td width=imgWidth align="center" valign="center">
+                <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
+                  <marko-newsletter-imgix
+                    src=coverImage.src
+                    alt=coverImage.alt
+                    options={ w: imgWidth }
+                    class="main"
+                    attrs={ border: 0, width: imgWidth }
+                  >
+                    <@link href=latestIssue.digitalEditionUrl  target="_blank" />
+                  </marko-newsletter-imgix>
+                </marko-core-obj-value>
+              </td>
+            </tr>
+            <tr>
+              <td width="100%" valign="top" style="padding-left: 20px;">
+                <common-table width="100%" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;">
+                  <tr>
+                    <td align="center">
+                        <if(latestIssue.digitalEditionUrl)>
+                          <a href=latestIssue.digitalEditionUrl target="_blank" style=contentLinkStyle>
+                            VIEW
+                          </a>
+                          the ${latestIssue.name} issue of <em>${latestIssue.publication.name}</em>.
+                        </if>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="center">
+                      <if(latestIssue.publication.subscribeUrl)>
+                        <a style=contentLinkStyle href=latestIssue.publication.subscribeUrl target="_blank" rel="noopener noreferrer">
+                          SUBSCRIBE
+                        </a>
+                      </if>
+                      <else>
+                        <a style=contentLinkStyle href=`${website.get("origin")}/subscribe` target="_blank" rel="noopener noreferrer">
+                          <strong>SUBSCRIBE</strong>
+                        </a>
+                      </else>
+                      for more leading edge content from <em>${latestIssue.publication.name}</em>!
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+          </if>
+          <else>
           <tr>
             <td width=imgWidth align="center" valign="center">
               <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
@@ -82,6 +135,7 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
               </common-table>
             </td>
           </tr>
+          </else>
         </common-table>
       </marko-web-query>
     </td>

--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -1,15 +1,14 @@
-import defaultValue from "@base-cms/marko-core/utils/default-value";
 import { getAsArray, getAsObject } from "@base-cms/object-path";
 
 $ const {
   newsletter,
   date,
-  imagePath
+  imagePath,
+  dateStyle,
 } = input;
 
 $ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
 $ const config = alphaThemeConfigs[0] ? getAsObject(alphaThemeConfigs[0], 'node') : null;
-$ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; color: #6b6b6b; font: 700 12px/18px Helvetica, 'Helvetica Neue', Arial, sans-serif;");
 
 <if(config && config.headerLeft)>
   <common-table width="700" style="border-collapse:collapse;" align="center" class="main header image-only-header" padding=0 spacing=0>
@@ -18,17 +17,9 @@ $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; co
     </tr>
     <tr>
       <td bgcolor=config.headerBgColor>
-        <common-style-b-config-header-images config=config alt=newsletter.name newsletter=newsletter/>
+        <common-style-b-config-header-images config=config alt=newsletter.name newsletter=newsletter date=date date-style=dateStyle/>
       </td>
     </tr>
-    <if('hide' !== config.dateToggle)>
-      $ const configDateStyle = config.headerTextColor ? `${dateStyle} color: ${config.headerTextColor}` : dateStyle;
-      <tr>
-        <td style=configDateStyle>
-          ${date.format(config.dateToggle)}
-        </td>
-      </tr>
-    </if>
   </common-table>
 </if>
 <else>

--- a/packages/common/components/style-b/elements/config-header-images.marko
+++ b/packages/common/components/style-b/elements/config-header-images.marko
@@ -1,7 +1,9 @@
-$ const { config, alt, newsletter } = input;
-$ const mainTableStyle = "border-collapse:collapse; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 
+$ const { config, alt, newsletter, date } = input;
+$ const mainTableStyle = "border-collapse:collapse; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const headerLink = config.headerLink ? config.headerLink : `https://${newsletter.site.host}`;
+$ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; color: #6b6b6b; font: 700 12px/18px Helvetica, 'Helvetica Neue', Arial, sans-serif;");
 
 <if(config)>
   <if(config.headerTemplate === 'image-full-700px')>
@@ -18,6 +20,16 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
           </marko-newsletter-imgix>
         </td>
       </tr>
+    </common-table>
+    <common-table width="700" align="center" style=`${mainTableStyle}` class="main" padding=0 spacing=0>
+      <if('hide' !== config.dateToggle)>
+        $ const configDateStyle = config.headerTextColor ? `${dateStyle} color: ${config.headerTextColor}` : dateStyle;
+        <tr>
+          <td style=configDateStyle>
+            ${date.format(config.dateToggle)}
+          </td>
+        </tr>
+      </if>
     </common-table>
   </if>
   <else>
@@ -53,6 +65,14 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
     </if>
     <else>
       <common-table width="340" align="right" style='margin-top: 10px;' class="mobileHide" padding=5 spacing=0>
+        <if('hide' !== config.dateToggle)>
+          $ const configDateStyle = config.headerTextColor ? `${dateStyle} color: ${config.headerTextColor}` : dateStyle;
+          <tr>
+            <td align="right" style=`padding-right: 20px; ${configDateStyle}`>
+              ${date.format(config.dateToggle)}
+            </td>
+          </tr>
+        </if>
         <tr>
           <td valign="top" align="right">
             <common-social-icons-element newsletter=newsletter/>

--- a/packages/common/components/style-b/elements/marko.json
+++ b/packages/common/components/style-b/elements/marko.json
@@ -13,6 +13,8 @@
     "template": "./config-header-images.marko",
     "@config": "object",
     "@newsletter": "object",
-    "@alt": "string"
+    "@alt": "string",
+    "@date-style": "string",
+    "@date": "date"
   }
 }

--- a/tenants/fleetmaintenance/templates/fms-digital-edition.marko
+++ b/tenants/fleetmaintenance/templates/fms-digital-edition.marko
@@ -1,0 +1,55 @@
+$ const { newsletter, date } = data;
+$ const publicationId = "53cd1d791784f8066eb2ca76";
+$ const publicationDescription = "Fleet Maintenance magazine delivers best practices for fleet maintenance managers to keep their vehicles operating with minimal downtime. Fleet Maintenance delivers information in chapter format for best peer practices, categorized under equipment, in the bay, and shop operations.";
+$ const titleTableStyle = "margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
+$ const titleStyle = "font: 700 15px/23px Arial, Helvetica, sans-serif; margin-top: 9px; margin-left: 20px; margin-bottom: 9px;";
+$ const mainTableStyle = "border-collapse:collapse; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#d00a2d",
+  "font": "700 19.5px/20px Arial, Helvetica, sans-serif",
+};
+$ const buttonStyle = "border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #d00a2d;";
+$ const buttonTextStyle = {
+  "color": "#ffffff",
+  "font": "700 14px/21px Helvetica, Arial, sans-serif",
+  "text-decoration": "none",
+  "text-transform": "uppercase"
+};
+
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-a-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+      teaser=newsletter.teaser
+    />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
+    <common-section-spacer-element />
+
+    <!-- Magazine -->
+    <common-publication-block
+      date=date
+      newsletter=newsletter
+      publication-id=publicationId
+      publication-description=publicationDescription
+      content-link-style=featuredContentLinkStyle
+      main-table-style=featuredMainTableStyle
+      img-width=225
+      table-width=420
+    />
+
+    <common-section-spacer-element />
+
+    <common-style-a-opt-out-block newsletter=newsletter/>
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/fleetmaintenance/templates/fms-digital-edition.marko
+++ b/tenants/fleetmaintenance/templates/fms-digital-edition.marko
@@ -43,6 +43,7 @@ $ const buttonTextStyle = {
       publication-description=publicationDescription
       content-link-style=contentLinkStyle
       main-table-style=mainTableStyle
+      img-width=600
     />
 
     <common-section-spacer-element />

--- a/tenants/fleetmaintenance/templates/fms-digital-edition.marko
+++ b/tenants/fleetmaintenance/templates/fms-digital-edition.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -41,10 +41,8 @@ $ const buttonTextStyle = {
       newsletter=newsletter
       publication-id=publicationId
       publication-description=publicationDescription
-      content-link-style=featuredContentLinkStyle
-      main-table-style=featuredMainTableStyle
-      img-width=225
-      table-width=420
+      content-link-style=contentLinkStyle
+      main-table-style=mainTableStyle
     />
 
     <common-section-spacer-element />


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-445

https://app.emailonacid.com/app/acidtest/sYOpJ2tzjupD0CL0XOHZgq850ll4ZFfDbDLRF445ESedm/list

Adjusted settings for 350px headers so that date could display next to the header image, rather than below it
![FM-digital-edition](https://user-images.githubusercontent.com/6343242/104334517-75b23780-54c0-11eb-975c-4e6e2fbbb22e.png)

Single headers will display as they do currently
<img width="785" alt="Screen Shot 2021-01-12 at 10 24 42 AM" src="https://user-images.githubusercontent.com/6343242/104334530-7b0f8200-54c0-11eb-96f7-e3b021a1eb0e.png">

Sample mobile photos from iPhone and Android:
![pixel-gmail](https://user-images.githubusercontent.com/6343242/104335916-d8f09980-54c1-11eb-89bd-a7a9686f7523.png)
![iphoneX](https://user-images.githubusercontent.com/6343242/104335926-db52f380-54c1-11eb-821a-ea35fc45769c.png)

