### PR TITLE
Display advertisement section only if ad exists

### DIFF
--- a/packages/common/components/style-a/blocks/leaderboard-primary.marko
+++ b/packages/common/components/style-a/blocks/leaderboard-primary.marko
@@ -1,15 +1,21 @@
 $ const { name, date } = input;
 
-<common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
-  <tr>
-    <td style="padding: 0 15px 15px 15px; min-width: 100%;">
-      <h3 style="font: 700 11px/16px Helvetica, Arial, sans-serif;margin: 5px; color: #999; text-align: left;">
-        Advertisement
-      </h3>
-      <common-advertisement-element
-        name=name
-        date=date
-      />
-    </td>
-  </tr>
-</common-table>
+<marko-newsletters-email-x-data|{ response }| decoded-params=["email", "send"]>
+  <@ad-unit ...name />
+  <@params date=input.date email="@{email name}@" send="@{track_id}@" />
+  <if(response)>
+    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="padding: 0 15px 15px 15px; min-width: 100%;">
+              <h3 style="font: 700 11px/16px Helvetica, Arial, sans-serif;margin: 5px; color: #999; text-align: left;">
+                Advertisement
+              </h3>
+          <common-advertisement-element
+            name=name
+            date=date
+          />
+        </td>
+      </tr>
+    </common-table>
+  </if>
+</marko-newsletters-email-x-data>


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-505

Currently displays an empty advertisement section if no ad exists:
<img width="730" alt="Screen Shot 2021-02-12 at 12 16 21 PM" src="https://user-images.githubusercontent.com/6343242/107799984-30d22880-6d2c-11eb-9216-634cf831633b.png">

New will still display if an ad exists, but won't display the section at all if no ad exists
<img width="794" alt="Screen Shot 2021-02-12 at 12 14 56 PM" src="https://user-images.githubusercontent.com/6343242/107800021-3fb8db00-6d2c-11eb-8752-864516806fd7.png">
<img width="759" alt="Screen Shot 2021-02-12 at 12 14 49 PM" src="https://user-images.githubusercontent.com/6343242/107800022-40517180-6d2c-11eb-978f-b64ee455ffae.png">

