### PR TITLE
SBT eNL spacing adjustments

### DIFF
--- a/packages/common/components/style-b/blocks/title-teaser.marko
+++ b/packages/common/components/style-b/blocks/title-teaser.marko
@@ -41,12 +41,24 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
               </td>
             </tr>
           </if>
-          <td valign="top" style="padding: 20px;">
-            <for|node, index| of=nodes>
-              <common-content-link-element node=node content-link-style=contentLinkStyle />
-              <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
-            </for>
-          </td>
+          <for|node, index| of=nodes>
+            <tr>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td style="padding: 0 20px;">
+                <common-content-link-element node=node content-link-style=contentLinkStyle />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 20px;">
+                <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+              </td>
+            </tr>
+            <tr>
+              <td>&nbsp;</td>
+            </tr>
+          </for>
         </common-table>
       </marko-web-query>
     </td>

--- a/tenants/smartbuildingstech/templates/smart-buildings-technology-report.marko
+++ b/tenants/smartbuildingstech/templates/smart-buildings-technology-report.marko
@@ -1,6 +1,6 @@
 $ const { newsletter, date } = data;
 
-$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Garamond, serif; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Garamond, serif; margin: 0; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const contentLinkStyle = {
   "font": "bold 19.5px/20px Arial, 'Helvetica Neue', Helvetica, sans-serif",
   "color": "#00944d",
@@ -117,7 +117,7 @@ $ const featuredButtonTextStyle = {
           <!-- scheduled content 7 and 8 -->
           <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
             <tr>
-              <td align="left" width="380">
+              <td valign="top" align="left">
                 <!-- #07 - Product Article - With Image - 82609 -->
                 <common-style-b-left-product-section-wrapper
                   section-id=82609
@@ -127,7 +127,7 @@ $ const featuredButtonTextStyle = {
                   width=360
                 />
               </td>
-              <td align="right" width="300" >
+              <td valign="top" align="right">
                 <!-- #08 - Medium Rectangle / 300x250 advertisement - 82610 -->
                 <common-promotion-advertisement-element
                   section-id=82610


### PR DESCRIPTION
- Removed border-top/bottom around tables
- Added additional spacing between content in title-teaser
- Align content to top of row so both columns line up equally

![image](https://user-images.githubusercontent.com/12496550/113927216-cb8e3700-97b2-11eb-9215-0eb11e588d31.png)

![image](https://user-images.githubusercontent.com/12496550/113927229-d052eb00-97b2-11eb-8761-5a2e5e626f87.png)


