### PR TITLE
New eNL for piprocessinstrumentation.com

### DIFF
--- a/packages/common/components/style-b/blocks/card-section-wrapper.marko
+++ b/packages/common/components/style-b/blocks/card-section-wrapper.marko
@@ -11,6 +11,7 @@ $ const {
   limit,
   skip,
   teaserStyle
+  linkTextStyle
 } = input;
 $ const titleStyle = defaultValue(input.titleStyle, "font: bold 16px/24px 'Helvetica Neue', Helvetica, sans-serif; margin: 0;");
 $ const titleTableStyle = defaultValue(input.titleTableStyle, titleStyle + "table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #000; background-color: #ffffff;");
@@ -59,6 +60,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     alignment=alignment
                     content-link-style=contentLinkStyle
                     teaser-style=teaserStyle
+                    link-text-style=linkTextStyle
                   />
                 </else>
               </for>

--- a/packages/common/components/style-b/blocks/card-section-wrapper.marko
+++ b/packages/common/components/style-b/blocks/card-section-wrapper.marko
@@ -10,7 +10,8 @@ $ const {
   title,
   limit,
   skip,
-  teaserStyle
+  teaserStyle,
+  customPromotionDisplay,
   linkTextStyle
 } = input;
 $ const titleStyle = defaultValue(input.titleStyle, "font: bold 16px/24px 'Helvetica Neue', Helvetica, sans-serif; margin: 0;");
@@ -51,7 +52,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
             <td valign="top">
               <for|node, index| of=nodes>
                 $ const alignment = getAlignment(index);
-                <if(node.type === "promotion")>
+                <if(node.type === "promotion" && customPromotionDisplay === true)>
                     <common-style-a-promotion-block node=node alignment=alignment content-link-style=contentLinkStyle teaser-style=teaserStyle />
                 </if>
                 <else>

--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -91,7 +91,11 @@
     "@title-style": "string",
     "@teaser-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@custom-promotion-display": {
+      "type": "boolean",
+      "default-value": true
+    },
     "@link-text-style": "object"
   },
   "<common-style-b-left-product-section-wrapper>": {

--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -43,7 +43,8 @@
       "default-value": 300
     },
     "@content-link-style": "object",
-    "@teaser-style": "object"
+    "@teaser-style": "object",
+    "@link-text-style": "object"
   },
   "<common-style-b-simple-card-full-block>": {
     "template": "./simple-card-full.marko",
@@ -91,6 +92,7 @@
     "@teaser-style": "object",
     "@main-table-style": "string",
     "@content-link-style": "object"
+    "@link-text-style": "object"
   },
   "<common-style-b-left-product-section-wrapper>": {
     "template": "./left-product-section-wrapper.marko",

--- a/packages/common/components/style-b/blocks/simple-card-half.marko
+++ b/packages/common/components/style-b/blocks/simple-card-half.marko
@@ -27,7 +27,12 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
           <td style="line-height: 175%; mso-line-heigh-rule: exactly; mso-line-height-alt: 146%;">
             <common-primary-image-element node=node img-width=imgWidth class-name="main" />
             <common-content-link-element node=node content-link-style=contentLinkStyle />
-            <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+            <if(node.type === "promotion" && node.body)>
+              <common-content-teaser-element node=node teaser-style=teaserStyle field="body" tag="p" />
+            </if>
+            <else>
+              <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+            </else>
           </td>
         </tr>
       </common-table>

--- a/packages/common/components/style-b/blocks/simple-card-half.marko
+++ b/packages/common/components/style-b/blocks/simple-card-half.marko
@@ -1,4 +1,5 @@
 import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const {
   node,
@@ -11,6 +12,7 @@ $ const {
 
 $ const innerPadding = 20;
 $ const innerTableWidth = tableWidth - (innerPadding * 2);
+$ const linkTextStyle = defaultValue(input.linkTextStyle, "font: bold 14px/16px Arial, Helvetica, sans-serif; color: #d5211c;");
 
 <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align=alignment class=`${alignment} main simple-card-half` padding=0 spacing=0>
   <tr>
@@ -33,6 +35,17 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
             <else>
               <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
             </else>
+            <if(node.type === "promotion" && node.linkText)>
+              <common-table align="left" padding=0 spacing=0>
+                <tr>
+                  <td style="margin:10px 0;">
+                    <marko-core-text value=node.linkText>
+                      <@link href=node.siteContext.url target="_blank" attrs={ style: linkTextStyle } />
+                    </marko-core-text>
+                    </td>
+                  </tr>
+              </common-table>
+            </if>
           </td>
         </tr>
       </common-table>

--- a/packages/common/components/style-b/blocks/title-teaser.marko
+++ b/packages/common/components/style-b/blocks/title-teaser.marko
@@ -52,7 +52,12 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
             </tr>
             <tr>
               <td style="padding: 0 20px;">
-                <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+                <if(node.type === "promotion" && node.body)>
+                  <common-content-teaser-element node=node teaser-style=teaserStyle field="body" tag="p" />
+                </if>
+                <else>
+                  <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+                </else>
               </td>
             </tr>
             <tr>

--- a/tenants/piprocessinstrumentation/templates/pi-process-instrumentation-solutions-center.marko
+++ b/tenants/piprocessinstrumentation/templates/pi-process-instrumentation-solutions-center.marko
@@ -1,0 +1,74 @@
+$ const { newsletter, date } = data;
+$ const mainTableStyle = "border-collapse:collapse; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const buttonTextStyle = {
+  "color": "#d5211c",
+  "font": "bold 16px/22px Arial, Helvetica, sans-serif"
+};
+$ const buttonStyle = "background-color: transparent; padding: 5px 20px;";
+$ const teaserStyle = "text-decoration: none !important; font: normal 14px Arial,Helvetica, sans-serif; color: #777;"
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-table width="700" padding="0" align="center" style="border-collapse:collapse;" class="main">
+            <tr>
+              <td height="6" bgcolor="#d5211c"></td>
+            </tr>
+          </common-table>
+
+          <!-- #01 Top Story - 1 Column - 65478 -->
+          <common-style-b-title-teaser-block
+            section-id=65478
+            date=date
+            limit=1
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            teaser-style=teaserStyle
+            content-link-style={
+              "font": "bold 24px Trebuchet MS, Helvetica, sans-serif;",
+              "color": "#333",
+              "text-decoration": "none"
+            };
+          />
+
+          <!-- #2 Sponsored - 2 Column - 65479 -->
+          <common-style-b-card-section-wrapper-block
+            section-id=65479
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            custom-promotion-display=false
+            content-link-style={
+              "font": "bold 16px Trebuchet MS, Helvetica, sans-serif;",
+              "color": "#333",
+              "text-decoration": "none"
+            };
+          />
+
+          <common-section-spacer-element />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/piprocessinstrumentation/templates/weekly-update.marko
+++ b/tenants/piprocessinstrumentation/templates/weekly-update.marko
@@ -36,7 +36,7 @@ $ const buttonStyle = "background-color: transparent; padding: 5px 20px;";
             date=date
             teaser=newsletter.teaser
           />
-          <common-style-b-image-only-header-block image-path="https://img.piprocessinstrumentation.com/files/base/ebm/fcn/image/static/eNL_Header_FC.jpg" date=date newsletter=newsletter />
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
           <common-section-spacer-element />
 


### PR DESCRIPTION
"PI Process Instrumentation Solutions Center", intended to mimic  https://email.stormh2o.com/stormwater-solutions-center/2021/05/04 as closely as possible.  

Jira ticket: https://southcomm.atlassian.net/browse/DEV-662

- Removed the hard-coded header image url on their other newsletter, unrelated to this it just bugged me.  Now the user is able to upload an image through the UI should they ever need to update it.
- Set body to display over teaser if the content type is a Promotion (other content can't pull the Body, only the Teaser, so this is fallback)
- Option to display Promotions like other content types (This is so Promotions pull the same card block as other content types so they display similarly, with the addition of a link text field, and pulling the Body instead of the Teaser).
<img width="952" alt="Screen Shot 2021-06-03 at 2 10 33 PM" src="https://user-images.githubusercontent.com/12496550/120692808-4358a500-c476-11eb-89c7-27e60ba361fa.png">
